### PR TITLE
Make the $ explicity jQuery in case $ is set to something else

### DIFF
--- a/src/core.coffee
+++ b/src/core.coffee
@@ -21,6 +21,8 @@ root = (exports ? this)
 kartograph = root.$K = window.Kartograph = root.Kartograph ?= {}
 kartograph.version = "0.4.0"
 
+$ = root.jQuery
+
 __verbose__ = false and console?
 
 warn = (s) ->


### PR DESCRIPTION
This is a very small update to explicit define $ locally as jQuery in case it is set to something else globally.  Often this is implemented with:

   (function($) {   })(jQuery);

But this will work fine.

My specific use case is that I have to deal with multiple versions of jQuery on the page (long story) and need to be explicit about witch one to use.

Do note that I did not change the built version.
