### PR TITLE
Fix missing path bug.

### DIFF
--- a/src/core/path.coffee
+++ b/src/core/path.coffee
@@ -193,7 +193,7 @@ Path.fromSVG = (path) ->
 				if contour.length > 2
 					contours.push contour
 					contour = []
-		if contour.length > 2
+		if contour.length >= 2
 			contours.push contour
 			contour = []
 


### PR DESCRIPTION
Some paths (e.g. `<path d="M84.903099,239.154945L142.275629,255.501356 "/>`) will be lost.
Just fix it.
