### PR TITLE
Fix test for string type

### DIFF
--- a/kartograph.js
+++ b/kartograph.js
@@ -4097,7 +4097,7 @@
     */
 
     me = this;
-    if (type(cmds) === 'string') {
+    if (__type(cmds) === 'string') {
       cmds = cmds.split("");
     }
     if (cmds.length === 0) {


### PR DESCRIPTION
The test for the string type on the cmds parameter in getGeoPathStr() at line 4100 fails because `type()` is used instead of `__type()`.
