### PR TITLE
IE7 and IE8 support for choropleth maps

### DIFF
--- a/src/core/maplayerpath.coffee
+++ b/src/core/maplayerpath.coffee
@@ -27,7 +27,8 @@ class MapLayerPath
         me.vpath = view.projectPath(path)
         me.svgPath = me.vpath.toSVG(paper)
         if not map.styles?
-            me.svgPath.node.setAttribute('class', layer_id)
+            if Raphael.svg
+                me.svgPath.node.setAttribute('class', layer_id)
         else
             map.applyCSS me.svgPath,layer_id
 


### PR DESCRIPTION
With this little change, choropleth maps get rendered with VML, albeit without borders on the polygons. Fixes #17.

I noticed another issue when debugging with the `showcase/choropleth` example on IE8: downloading the SVG via ajax fails with a parsererror, which goes away if you remove the DOCTYPE from the SVG file. In another test, in my application, an SVG with DOCTYPE was loaded with no error. Not sure what's going on here.
