### PR TITLE
Attribute "labelattr" doesn´t work properly for LabeledBubble Symbol

### DIFF
--- a/src/modules/symbols/labeledbubble.coffee
+++ b/src/modules/symbols/labeledbubble.coffee
@@ -61,7 +61,9 @@ class LabeledBubble extends Bubble
                     'stroke-linecap': 'round'
                     'stroke-width': 6
             me.label.attr attrs
-            me.label.toFront()
+            me.label.toFront
+            me.label.node.setAttribute 'style', attrs['style']
+            me.label.node.setAttribute 'class', attrs['class']
         me
 
 


### PR DESCRIPTION
If you want to add a bubble with a label to the map you probably use the attribute "labelattr" to add a class to the text element.

But the attribute "css" and "style" are not applied to the text element in the svg xml schema.

This is a workaround to fix the problem.
