### PR TITLE
Update kartograph.js

### DIFF
--- a/dist/kartograph.js
+++ b/dist/kartograph.js
@@ -1780,7 +1780,7 @@
       this.x = x;
       this.y = y;
       this.r = r;
-      Circle.__super__.constructor.call(this, 'circle', null, true);
+      Circle.__super__.constructor.call(this, 'circle', [], true);
     }
 
     Circle.prototype.toSVG = function(paper) {


### PR DESCRIPTION
I'm using this fix to make kartograph.js work in our app. Other wise it crashes with

```
Uncaught TypeError: Cannot read property 'length' of null
```

the null is `contours` in 

```
 Path = (function() {
    /*
        represents complex polygons (aka multi-polygons)
    */
    function Path(type, contours, closed) {
      var cnt, self, _i, _len;

      if (closed == null) {
        closed = true;
      }
      self = this;
      self.type = type;
      self.contours = [];
      for (_i = 0, _len = contours.length; _i < _len; _i++) {
        cnt = contours[_i];
        if (!__is_clockwise(cnt)) {
          cnt.reverse();
        }
        self.contours.push(cnt);
      }
      self.closed = closed;
    }
```

I suppose I should make a pull request with changes in your *.coffee source files, but I don't know how to.
